### PR TITLE
docs: remove irrelevant info

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,16 +94,6 @@ CJS, ESModules, and UMD module formats are supported.
 
 The appropriate paths are configured in `package.json` and `dist/index.js` accordingly. Please report if any issues are found.
 
-## Named Exports
-
-Per Palmer Group guidelines, [always use named exports.](https://github.com/palmerhq/typescript#exports) Code split inside your React app instead of your React library.
-
-## Including Styles
-
-There are many ways to ship styles, including with CSS-in-JS. TSDX has no opinion on this, configure how you like.
-
-For vanilla CSS, you can include it at the root directory and add it to the `files` section in your `package.json`, so that it can be imported separately by your users and run through their bundler's loader.
-
 ## Publishing to NPM
 
 We recommend using [np](https://github.com/sindresorhus/np).

--- a/package.json
+++ b/package.json
@@ -62,5 +62,8 @@
       "released"
     ],
     "onlyPublishWithReleaseLabel": true
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.1.1--canary.3.78fbc05.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @lifechurch/facebook-pixel@0.1.1--canary.3.78fbc05.0
  # or 
  yarn add @lifechurch/facebook-pixel@0.1.1--canary.3.78fbc05.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
